### PR TITLE
Run parity if installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
-# parity.js
+# Parity Wallet
 
-JavaScript APIs and UIs for Parity.
+The Electron app of Parity Wallet user interface.
 
-## development
+## Development
 
 0. Install [Node](https://nodejs.org/) if not already available
-0. Change to the `js` directory inside `parity/`
 0. Install the npm modules via `npm install`
 0. Parity should be run with `parity --ui-no-validation [...options]` (where `options` can be `--chain testnet`)
 0. Start the development environment via `npm start`
-0. Connect to the [UI](http://localhost:3000)
+0. Connect to [http://localhost:3000](http://localhost:3000)
+
+If you wish to develop directly inside the Electron app, you can run parallely
+
+0. `npm run electron:dev`
+
+This will launch an Electron app listening to localhost:3000.
+
+Finally, to test the Electron app in an almost-production environment, run 
+
+0. `npm run electron`
+
+This will *not* listen to localhost:3000, but will instead bundle the whole app, and launch an Electron instance which launches the bundled app. If everything works using this command, there's a good chance that the final binary will work too.
+
+## Create Electron binaries on Travis
+
+Travis will do the dirty work of creating installers on all platforms. To do so, simply push your code to the `ci-package` branch.
+
+For example, if you do your modifications on your personal branch `my-branch` and want to build binaries for this branch, run:
+
+0. `git checkout ci-package`
+0. `git reset --hard my-branch` (copy my-branch to ci-package)
+0. `git push --force ci-package` (will overwrite the previous ci-package, but that's all right)
+
+Travis will trigger the binaries build when on `ci-package` branch. The binaries will then be uploaded to https://github.com/Parity-JS/shell/releases as drafts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3573,6 +3573,11 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "command-exists": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.2.tgz",
+      "integrity": "sha1-EoGcZPr5VEbsCuB/5sr7brNwiyI="
+    },
     "commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "Parity"
   ],
   "scripts": {
-    "build": "npm run build:inject && npm run build:app && npm run build:embed",
+    "build": "npm run build:inject && npm run build:app && npm run build:electron && npm run build:embed",
     "build:app": "webpack --config webpack/app",
+    "build:electron": "webpack --config webpack/electron",
     "build:inject": "webpack --config webpack/inject",
     "build:embed": "cross-env EMBED=1 node webpack/embed",
     "build:i18n": "npm run clean && npm run build && babel-node ./scripts/build-i18n.js",
@@ -42,7 +43,7 @@
     "lint:js": "eslint --ignore-path .gitignore ./src/",
     "lint:js:cached": "eslint --cache --ignore-path .gitignore ./src/",
     "lint:js:fix": "eslint --fix --ignore-path .gitignore ./src/",
-    "package": "npm run build && electron-builder --config package.electron.json",
+    "package": "npm run ci:build && electron-builder --config package.electron.json",
     "start": "npm run clean && npm install && npm run build:inject && npm run start:app",
     "start:app": "node webpack/dev.server",
     "test": "cross-env NODE_ENV=test mocha 'src/**/*.spec.js'",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@parity/plugin-signer-qr": "github:parity-js/plugin-signer-qr#c275ba13524e9f6759079fabd10faf49cc00cfc0",
     "@parity/shared": "2.2.25",
     "@parity/ui": "3.1.4",
+    "command-exists": "1.2.2",
     "is-electron": "2.1.0",
     "keythereum": "1.0.2",
     "lodash.flatten": "4.4.0",

--- a/src/Connection/connection.css
+++ b/src/Connection/connection.css
@@ -37,6 +37,7 @@
 .body {
   box-shadow: rgba(0, 0, 0, 0.25) 0 14px 45px, rgba(0, 0, 0, 0.22) 0 10px 18px;
   color: rgb(208, 208, 208);
+  background-color: #405161;
   margin: 0 auto;
   max-width: 40em;
   padding: 2em 4em;

--- a/src/Connection/connection.js
+++ b/src/Connection/connection.js
@@ -51,7 +51,7 @@ class Connection extends Component {
     validToken: false
   }
 
-  componentWillMount () {
+  componentDidMount () {
     if (isElectron()) {
       const { ipcRenderer, remote } = electron;
       const parityInstallLocation = remote.getGlobal('parityInstallLocation');

--- a/src/Connection/connection.js
+++ b/src/Connection/connection.js
@@ -185,7 +185,7 @@ class Connection extends Component {
         <FormattedMessage
           id='connection.noParity'
           defaultMessage="We couldn't find any Parity installation on this computer. If you have it installed, please run it now. If not, please follow the instructions on {link} to install Parity first."
-          values={ { link: <a onClick={ this.handleOpenWebsite }>https://parity.io</a> } }
+          values={ { link: <a href='#' onClick={ this.handleOpenWebsite }>https://parity.io</a> } }
         />
       </div>
     );

--- a/src/index.electron.js
+++ b/src/index.electron.js
@@ -62,14 +62,7 @@ function createWindow () {
   ipcMain.on('asynchronous-message', (event, arg) => {
     // Run an instance of parity if we receive the `run-parity` message
     if (arg === 'run-parity') {
-      const parity = spawn(global.parityInstallLocation);
-
-      // Parity logs are written to stderr by default. If we see one log, we
-      // assume that parity is running
-      parity.stderr.once('data', data => {
-        // Send message back when successfully launched
-        event.sender.send('asynchronous-reply', 'parity-running');
-      });
+      spawn(global.parityInstallLocation);
     }
   });
 

--- a/src/index.electron.js
+++ b/src/index.electron.js
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-const argv = require('yargs').argv;
+// eslint-disable-next-line
+const argv = __non_webpack_require__('yargs').argv; // Dynamic require https://github.com/yargs/yargs/issues/781
 const electron = require('electron');
 const path = require('path');
 const pick = require('lodash/pick');
@@ -47,7 +48,7 @@ function createWindow () {
     // TODO Check if file exists?
     mainWindow.loadURL(
       url.format({
-        pathname: path.join(__dirname, '../.build/index.html'),
+        pathname: path.join(__dirname, '..', '.build', 'index.html'),
         protocol: 'file:',
         slashes: true
       })

--- a/src/index.electron.js
+++ b/src/index.electron.js
@@ -26,7 +26,7 @@ const url = require('url');
 
 const parityInstallLocation = require('./util/parityInstallLocation');
 
-const { app, BrowserWindow, ipcMain, Menu, session } = electron;
+const { app, BrowserWindow, ipcMain, Menu, session, shell } = electron;
 let mainWindow;
 
 // Will send these variables to renderers via IPC
@@ -105,11 +105,49 @@ function createWindow () {
       submenu: [
         {
           label: 'Learn More',
-          click () { require('electron').shell.openExternal('https://parity.io'); }
+          click () { shell.openExternal('https://parity.io'); }
         }
       ]
     }
   ];
+
+  if (process.platform === 'darwin') {
+    template.unshift({
+      label: app.getName(),
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services', submenu: [] },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideothers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    });
+
+    // Edit menu
+    template[1].submenu.push(
+      { type: 'separator' },
+      {
+        label: 'Speech',
+        submenu: [
+          { role: 'startspeaking' },
+          { role: 'stopspeaking' }
+        ]
+      }
+    );
+
+    // Window menu
+    template[3].submenu = [
+      { role: 'close' },
+      { role: 'minimize' },
+      { role: 'zoom' },
+      { type: 'separator' },
+      { role: 'front' }
+    ];
+  }
 
   const menu = Menu.buildFromTemplate(template);
 

--- a/src/index.electron.js
+++ b/src/index.electron.js
@@ -20,12 +20,17 @@ const path = require('path');
 const pick = require('lodash/pick');
 const url = require('url');
 
+const isParityInstalled = require('./util/isParityInstalled');
+
 const { app, BrowserWindow, Menu, session } = electron;
 let mainWindow;
 
 // Will send these variables to renderers via IPC
 global.dirName = __dirname;
 Object.assign(global, pick(argv, ['wsInterface', 'wsPort']));
+isParityInstalled()
+  .then((installed) => { global.isParityInstalled = installed; })
+  .catch(() => { });
 
 function createWindow () {
   mainWindow = new BrowserWindow({

--- a/src/util/isParityInstalled.js
+++ b/src/util/isParityInstalled.js
@@ -1,0 +1,48 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+const commandExists = require('command-exists');
+const fs = require('fs');
+const util = require('util');
+
+const promiseAny = require('./promiseAny');
+
+const fsExists = util.promisify(fs.stat);
+
+// Locations to test if parity binary exists
+// TODO This could be improved
+const locations = {
+  linux: ['/bin/parity', '/usr/bin/parity', '/usr/local/bin/parity'],
+  darwin: ['/Applications/Parity Ethereum.app/Contents/MacOS/parity'],
+  win32: ['C:\\Program Files\\Parity Technologies\\Parity\\parity.exe']
+};
+
+/**
+ * This function checks if parity has been installed on the local machine:
+ * - first check if the program is in $PATH, using `command-exists`
+ * - then check the OS default installation dir if a parity folder exists
+ * This function should run in node env.
+ * Returns a string which is the command to run parity.
+ */
+const isParityInstalled = () => {
+  return commandExists('parity') // First test is `parity` command exists
+    .then(() => 'parity') // If yes, return `parity` as command
+    .catch(() => promiseAny(locations[process.platform].map(
+      location => fsExists(location).then(() => location) // Then test if OS-specific locations contain parity
+    )));
+};
+
+module.exports = isParityInstalled;

--- a/src/util/parityInstallLocation.js
+++ b/src/util/parityInstallLocation.js
@@ -37,12 +37,13 @@ const locations = {
  * This function should run in node env.
  * Returns a string which is the command to run parity.
  */
-const isParityInstalled = () => {
+const parityInstallLocation = () => {
   return commandExists('parity') // First test is `parity` command exists
     .then(() => 'parity') // If yes, return `parity` as command
     .catch(() => promiseAny(locations[process.platform].map(
       location => fsExists(location).then(() => location) // Then test if OS-specific locations contain parity
-    )));
+    )))
+    .catch(() => null); // Return null if no parity is found
 };
 
-module.exports = isParityInstalled;
+module.exports = parityInstallLocation;

--- a/src/util/promiseAny.js
+++ b/src/util/promiseAny.js
@@ -1,0 +1,40 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Resolves when the 1st promise in an array of promises resolves
+ * @see https://stackoverflow.com/questions/37234191/resolve-es6-promise-with-first-success
+ * @param {Array} promises
+ */
+const promiseAny = (promises) => {
+  return Promise.all(promises.map(p => {
+    // If a request fails, count that as a resolution so it will keep
+    // waiting for other possible successes. If a request succeeds,
+    // treat it as a rejection so Promise.all immediately bails out.
+    return p.then(
+      val => Promise.reject(val),
+      err => Promise.resolve(err)
+    );
+  }))
+    .then(
+      // If '.all' resolved, we've just got an array of errors.
+      errors => Promise.reject(errors),
+      // If '.all' rejected, we've got the result we wanted.
+      val => Promise.resolve(val)
+    );
+};
+
+module.exports = promiseAny;

--- a/webpack/app.js
+++ b/webpack/app.js
@@ -174,7 +174,7 @@ module.exports = {
         plugins,
 
         new HtmlWebpackPlugin({
-          title: 'Parity',
+          title: 'Parity Wallet',
           filename: 'index.html',
           template: './index.parity.ejs',
           favicon: FAVICON,
@@ -194,10 +194,6 @@ module.exports = {
             {
               from: path.join(__dirname, '../src/error_pages.css'),
               to: 'styles.css'
-            },
-            {
-              from: path.join(__dirname, '../src/index.electron.js'),
-              to: 'electron.js'
             },
             {
               from: path.join(__dirname, '../package.electron.json'),

--- a/webpack/electron.js
+++ b/webpack/electron.js
@@ -1,0 +1,61 @@
+
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+const path = require('path');
+
+const rulesEs6 = require('./rules/es6');
+const rulesParity = require('./rules/parity');
+const Shared = require('./shared');
+
+const DEST = process.env.BUILD_DEST || '.build';
+const ENV = process.env.NODE_ENV || 'development';
+
+const isProd = ENV === 'production';
+
+module.exports = {
+  cache: !isProd,
+  devtool: '#source-map',
+  context: path.join(__dirname, '../src'),
+  entry: { electron: './index.electron.js' },
+  output: {
+    path: path.join(__dirname, '../', DEST),
+    filename: '[name].js'
+  },
+  node: {
+    __dirname: false
+  },
+  target: 'electron-main',
+
+  module: {
+    rules: [
+      rulesParity,
+      rulesEs6,
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [{
+          loader: 'happypack/loader',
+          options: {
+            id: 'babel'
+          }
+        }]
+      }
+    ]
+  },
+
+  plugins: Shared.getPlugins()
+};


### PR DESCRIPTION
This PR does, on UI launch, the follwing
  - if parity running, do nothing
  - if parity installed and not running, run parity
  - if parity not installed, show download instructions

To test:
1. Open UI with parity running -> Shoudl work as before
2. Don't run parity and open UI -> Should spawn a parity instance (i.e. `ps aux | grep parity` should list parity). Note: since parity is run as a child process, closing the UI will close parity as well.
3. `sudo mv /path/to/parity /path/to/parity.bak`, launch UI -> Should show download instructions
