### PR TITLE
Fix bug parity not closed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ deploy:
   - provider: releases
     api_key: $GH_TOKEN
     draft: true
-    name: Parity Wallet
+    name: Parity UI v0.1.0
     file:
-      - ./dist/parity-wallet_0.1.0_amd64.deb
-      - ./dist/parity-wallet_0.1.0_amd64.snap
-      - ./dist/parity-wallet-0.1.0-x86_64.AppImage
+      - ./dist/parity-ui_0.1.0_amd64.deb
+      - ./dist/parity-ui_0.1.0_amd64.snap
+      - ./dist/parity-ui-0.1.0-x86_64.AppImage
     skip_cleanup: true
     on:
       condition: $TRAVIS_OS_NAME = linux
@@ -37,10 +37,10 @@ deploy:
   - provider: releases
     api_key: $GH_TOKEN
     draft: true
-    name: Parity Wallet
+    name: Parity UI v0.1.0
     file:
-      - "./dist/Parity Wallet Setup 0.1.0.exe"
-      - "./dist/Parity Wallet-0.1.0.dmg"
+      - "./dist/Parity UI Setup 0.1.0.exe"
+      - "./dist/Parity UI-0.1.0.dmg"
     skip_cleanup: true
     on:
       condition: $TRAVIS_OS_NAME = osx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Parity Wallet
+# Parity UI
 
-The Electron app of Parity Wallet user interface.
+The Electron app for Parity UI.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "parity-wallet",
+  "name": "parity-ui",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.electron.json
+++ b/package.electron.json
@@ -1,5 +1,5 @@
 {
-  "appId": "com.parity.wallet",
+  "appId": "com.parity.ui",
   "directories": {
     "buildResources": "./"
   },
@@ -15,7 +15,7 @@
     "category": "public.app-category.productivity",
     "icon": "./assets/icon/small-white-512x512.png"
   },
-  "productName": "Parity Wallet",
+  "productName": "Parity UI",
   "win": {
     "icon": "./assets/icon/small-white-512x512.png"
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "parity-wallet",
+  "name": "parity-ui",
   "version": "0.1.0",
   "main": ".build/electron.js",
   "jsnext:main": ".build/electron.js",

--- a/webpack/app.js
+++ b/webpack/app.js
@@ -174,7 +174,7 @@ module.exports = {
         plugins,
 
         new HtmlWebpackPlugin({
-          title: 'Parity Wallet',
+          title: 'Parity UI',
           filename: 'index.html',
           template: './index.parity.ejs',
           favicon: FAVICON,


### PR DESCRIPTION
While playing with Electron installed via .dmg, I found out when parity is launched by UI, and when I close UI, parity actually doesn't stop (different behavior when using `npm run electron`). This PR forces parity to stop when electron stops.

Also rename Parity Wallet -> Parity UI.

@jacogr If you want to test this, in https://github.com/Parity-JS/shell/releases there's a draft version which contains binaries with this PR's changes. I tested on windows and osx and both works, would like you to play a bit with it too.