### PR TITLE
Change windows config

### DIFF
--- a/package.electron.json
+++ b/package.electron.json
@@ -17,7 +17,8 @@
   },
   "nsis": {
     "allowToChangeInstallationDirectory": true,
-    "onClick": false
+    "include": "installer.nsh",
+    "oneClick": false
   },
   "productName": "Parity UI",
   "win": {

--- a/package.electron.json
+++ b/package.electron.json
@@ -1,5 +1,5 @@
 {
-  "appId": "com.parity.ui",
+  "appId": "io.parity.ui",
   "directories": {
     "buildResources": "./"
   },
@@ -15,8 +15,13 @@
     "category": "public.app-category.productivity",
     "icon": "./assets/icon/small-white-512x512.png"
   },
+  "nsis": {
+    "allowToChangeInstallationDirectory": true,
+    "onClick": false
+  },
   "productName": "Parity UI",
   "win": {
-    "icon": "./assets/icon/small-white-512x512.png"
+    "icon": "./assets/icon/small-white-512x512.png",
+    "target": "nsis"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": ".build/electron.js",
   "jsnext:main": ".build/electron.js",
   "author": {
-    "name": "Parity Team",
+    "name": "Parity Technologies",
     "email": "admin@parity.io"
   },
   "maintainers": [

--- a/src/index.electron.js
+++ b/src/index.electron.js
@@ -160,7 +160,7 @@ function createWindow () {
   session.defaultSession.webRequest.onBeforeSendHeaders({
     urls: ['ws://*/*', 'wss://*/*']
   }, (details, callback) => {
-    details.requestHeaders.Origin = `parity://${mainWindow.id}.wallet.parity`;
+    details.requestHeaders.Origin = `parity://${mainWindow.id}.ui.parity`;
     callback({ requestHeaders: details.requestHeaders });
   });
 

--- a/src/util/windowInstaller.nsh
+++ b/src/util/windowInstaller.nsh
@@ -1,0 +1,10 @@
+; Change default install directory on Windows
+; https://www.electron.build/configuration/nsis#how-do-change-the-default-installation-directory-to-custom
+macro preInit
+    SetRegView 64
+    WriteRegExpandStr HKLM "${INSTALL_REGISTRY_KEY}" InstallLocation "C:\Program Files\Parity Technologies\Parity UI"
+    WriteRegExpandStr HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation "C:\Program Files\Parity Technologies\Parity UI"
+    SetRegView 32
+    WriteRegExpandStr HKLM "${INSTALL_REGISTRY_KEY}" InstallLocation "C:\Program Files\Parity Technologies\Parity UI"
+    WriteRegExpandStr HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation "C:\Program Files\Parity Technologies\Parity UI"
+!macroend

--- a/webpack/electron.js
+++ b/webpack/electron.js
@@ -16,6 +16,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 const path = require('path');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const rulesEs6 = require('./rules/es6');
 const rulesParity = require('./rules/parity');
@@ -57,5 +58,8 @@ module.exports = {
     ]
   },
 
-  plugins: Shared.getPlugins()
+  plugins: Shared.getPlugins().concat(new CopyWebpackPlugin([{
+    from: path.join(__dirname, '../src/util/windowInstaller.nsh'),
+    to: 'installer.nsh'
+  }]))
 };


### PR DESCRIPTION
- Change some leftovers parity wallet -> parity ui
- Add a script on windows to change the default install directory (was AppData/... before): now it's `C:/Program Files/Parity Technologies/Parity UI` (next to parity core)