### PR TITLE
Feedback fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ deploy:
       - ./dist/parity-ui_0.1.0_amd64.deb
       - ./dist/parity-ui_0.1.0_amd64.snap
       - ./dist/parity-ui-0.1.0-x86_64.AppImage
+      - ./dist/parity-ui-0.1.0.tar.xz
     skip_cleanup: true
     on:
       condition: $TRAVIS_OS_NAME = linux

--- a/package.electron.json
+++ b/package.electron.json
@@ -8,7 +8,8 @@
     "target": [
       "AppImage",
       "snap",
-      "deb"
+      "deb",
+      "tar.xz"
     ]
   },
   "mac": {

--- a/package.electron.json
+++ b/package.electron.json
@@ -16,9 +16,9 @@
     "icon": "./assets/icon/small-white-512x512.png"
   },
   "nsis": {
-    "allowToChangeInstallationDirectory": true,
     "include": "./.build/installer.nsh",
-    "oneClick": false
+    "oneClick": true,
+    "perMachine": true
   },
   "productName": "Parity UI",
   "win": {

--- a/src/index.electron.js
+++ b/src/index.electron.js
@@ -63,7 +63,7 @@ function createWindow () {
   ipcMain.on('asynchronous-message', (event, arg) => {
     // Run an instance of parity if we receive the `run-parity` message
     if (arg === 'run-parity') {
-      parity = spawn(global.parityInstallLocation);
+      parity = spawn(global.parityInstallLocation, ['--ws-origins', 'parity://*.ui.parity']); // Argument for retro-compatibility with <1.10 versions
     }
   });
 


### PR DESCRIPTION
- Add tar.xz on linux
- Fix windows installer per-user/per-machine bug
- Run `parity` with `--ws-origins ...`. The `You have parity 1.9.4, please install 1.10` screen wouldn't show otherwise.