### PR TITLE
Remove console errors due to service worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8737,6 +8737,12 @@
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -10289,6 +10295,15 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "requires": {
+        "immediate": "3.0.6"
       }
     },
     "load-json-file": {
@@ -13396,6 +13411,16 @@
         "asap": "2.0.6"
       }
     },
+    "promise-worker": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-worker/-/promise-worker-1.1.1.tgz",
+      "integrity": "sha1-wrddBF0kliXAImTi3/mtIuAxxps=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0",
+        "lie": "3.3.0"
+      }
+    },
     "prop-types": {
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
@@ -15874,6 +15899,15 @@
       "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves=",
       "dev": true
     },
+    "serviceworker-webpack-plugin": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/serviceworker-webpack-plugin/-/serviceworker-webpack-plugin-0.2.3.tgz",
+      "integrity": "sha1-GHPtb8g8hzrIJA+sRDxhXTdP7rI=",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -17589,6 +17623,23 @@
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
+    "uri-js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
+      }
+    },
     "urijs": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
@@ -18434,6 +18485,46 @@
           "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
           "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "dev": true
+        }
+      }
+    },
+    "worker-loader": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-1.1.1.tgz",
+      "integrity": "sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.4.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+          "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,7 +447,7 @@
       }
     },
     "@parity/plugin-signer-account": {
-      "version": "github:parity-js/plugin-signer-account#3acd84ba1965f9ee419edd04d84e13e097e6d661",
+      "version": "github:parity-js/plugin-signer-account#bd4df5810ca57fd6f512ab33a6bfacc95d1b6b23",
       "requires": {
         "@parity/mobx": "1.1.2",
         "@parity/ui": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
   "dependencies": {
     "@parity/api": "2.1.20",
     "@parity/mobx": "1.1.2",
-    "@parity/plugin-signer-account": "github:parity-js/plugin-signer-account#3acd84ba1965f9ee419edd04d84e13e097e6d661",
+    "@parity/plugin-signer-account": "github:parity-js/plugin-signer-account#bd4df5810ca57fd6f512ab33a6bfacc95d1b6b23",
     "@parity/plugin-signer-default": "github:parity-js/plugin-signer-default#dcf8cf23bb050070b6a691413b974b5c2d7d1ce6",
     "@parity/plugin-signer-hardware": "github:parity-js/plugin-signer-hardware#e8b8a4e67adc37870e370d22805632d08012b9ee",
     "@parity/plugin-signer-qr": "github:parity-js/plugin-signer-qr#c275ba13524e9f6759079fabd10faf49cc00cfc0",

--- a/package.json
+++ b/package.json
@@ -124,12 +124,14 @@
     "postcss-nested": "2.1.0",
     "postcss-simple-vars": "4.0.0",
     "progress": "1.1.8",
+    "promise-worker": "1.1.1",
     "raw-loader": "0.5.1",
     "react-addons-perf": "15.4.2",
     "react-addons-test-utils": "15.6.2",
     "react-hot-loader": "3.1.3",
     "react-intl-aggregate-webpack-plugin": "0.0.1",
     "rimraf": "2.6.2",
+    "serviceworker-webpack-plugin": "0.2.3",
     "sinon": "1.17.7",
     "sinon-as-promised": "4.0.2",
     "sinon-chai": "2.8.0",
@@ -146,6 +148,7 @@
     "webpack-error-notification": "0.1.6",
     "webpack-hot-middleware": "2.17.1",
     "websocket": "1.0.24",
+    "worker-loader": "1.1.1",
     "yargs": "6.6.0"
   },
   "dependencies": {

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -1,0 +1,15 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.

--- a/webpack/app.js
+++ b/webpack/app.js
@@ -24,6 +24,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const WebpackErrorNotificationPlugin = require('webpack-error-notification');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin');
 
 const rulesEs6 = require('./rules/es6');
 const rulesParity = require('./rules/parity');
@@ -238,7 +239,12 @@ module.exports = {
             )
           ]),
           {}
-        )
+        ),
+
+        new ServiceWorkerWebpackPlugin({
+          entry: path.join(__dirname, '../src/serviceWorker.js'),
+          publicPath: path.join(__dirname, '../.build/')
+        }),
       );
     }
 


### PR DESCRIPTION
There are a lot of error messages due to service worker not present, and, while harmless, they tend to scare users.

This PR adds a service worker plugin to make service workers work:
- npm install --save-dev promise-worker serviceworker-webpack-plugin worker-loader
- add a (empty) service worker plugin for webpack
- also updated ref to latest plugin-signer-account (the css fix one)

To test:
- npm run electron
When electron pops up, there should be no service worker errors, but a `ServiceWorker is setup` message logged instead.

Closes https://github.com/parity-js/dapp-wallet/issues/6.