### PR TITLE
Fix #58: Avoid shifting UI on alert

### DIFF
--- a/src/Status/status.css
+++ b/src/Status/status.css
@@ -46,8 +46,12 @@ $statusHeight: 2.75em;
   }
 
   .warning {
-    background: red;
-    display: block;
+    background: orange;
+    opacity: 0.8;
+    position: absolute;
+    top: 38px;
+    z-index: 5;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
See #58 and https://github.com/paritytech/parity/issues/8422

While I don't find the solution amazing (this is more a workaround), it does fix the issue and makes the UI usable again. Please let me know if you see other options.

Is there by the way a UI guideline somewhere? I think the notification system in general would benefit some rework and I am sure you already have plan/ideas.  