### PR TITLE
Fix opening external links

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -55,10 +55,9 @@ function createWindow () {
     mainWindow.webContents.openDevTools();
   } else {
     // Opens file:///path/to/.build/index.html in prod mode
-    // TODO Check if file exists?
     mainWindow.loadURL(
       url.format({
-        pathname: path.join(__dirname, '..', 'index.html'),
+        pathname: path.join(__dirname, '..', '.build', 'index.html'),
         protocol: 'file:',
         slashes: true
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -337,18 +337,18 @@
       "dev": true
     },
     "@parity/dapp-status": {
-      "version": "github:js-dist-paritytech/dapp-status#ea6a3c01d64bd57c5fadf2264efa719a61e70a29",
+      "version": "github:js-dist-paritytech/dapp-status#d8b0adbdce9316ba22b416755ecb81a6917f4a86",
       "dev": true,
       "requires": {
         "@parity/api": "2.1.20",
         "@parity/mobx": "1.1.2",
         "@parity/ui": "3.1.4",
         "format-number": "3.0.0",
-        "mobx": "3.6.0",
+        "mobx": "3.6.2",
         "mobx-react": "4.3.5",
         "prop-types": "15.6.1",
-        "react": "16.2.0",
-        "react-dom": "16.2.0",
+        "react": "16.3.2",
+        "react-dom": "16.3.2",
         "react-intl": "2.4.0",
         "react-scripts": "1.0.17",
         "rlp": "2.0.0",
@@ -357,9 +357,9 @@
       },
       "dependencies": {
         "mobx": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/mobx/-/mobx-3.6.0.tgz",
-          "integrity": "sha1-IN4Hm34Vh0oQXVROnynbiiIp+eM=",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/mobx/-/mobx-3.6.2.tgz",
+          "integrity": "sha512-Dq3boJFLpZEvuh5a/MbHLUIyN9XobKWIb0dBfkNOJffNkE3vtuY0C9kSDVpfH8BB0BPkVw8g22qCv7d05LEhKg==",
           "dev": true
         },
         "prop-types": {
@@ -374,9 +374,9 @@
           }
         },
         "react": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-          "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+          "version": "16.3.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+          "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
           "dev": true,
           "requires": {
             "fbjs": "0.8.16",
@@ -386,9 +386,9 @@
           }
         },
         "react-dom": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-          "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+          "version": "16.3.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+          "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
           "dev": true,
           "requires": {
             "fbjs": "0.8.16",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "parity-ui",
   "version": "0.2.0",
   "description": "The Electron app for Parity UI",
-  "main": ".build/electron/index.js",
-  "jsnext:main": ".build/electron/index.js",
+  "main": ".build/electron.js",
+  "jsnext:main": ".build/electron.js",
   "author": {
     "name": "Parity Technologies",
     "email": "admin@parity.io"
@@ -37,8 +37,8 @@
     "ci:build": "cross-env NODE_ENV=production npm run build",
     "clean": "rimraf ./.build ./.coverage ./.happypack",
     "coveralls": "npm run testCoverage && coveralls < coverage/lcov.info",
-    "electron": "npm run build && electron .build/electron/",
-    "electron:dev": "electron electron/ --ui-dev",
+    "electron": "npm run build && electron .build/electron.js",
+    "electron:dev": "electron electron/ --dev",
     "lint": "npm run lint:css && npm run lint:js",
     "lint:cached": "npm run lint:css && npm run lint:js:cached",
     "lint:css": "stylelint ./src/**/*.css",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "clean": "rimraf ./.build ./.coverage ./.happypack",
     "coveralls": "npm run testCoverage && coveralls < coverage/lcov.info",
     "electron": "npm run build && electron .build/electron.js",
-    "electron:dev": "electron electron/ --dev",
+    "electron:dev": "electron electron/ --ui--dev",
     "lint": "npm run lint:css && npm run lint:js",
     "lint:cached": "npm run lint:css && npm run lint:js:cached",
     "lint:css": "stylelint ./src/**/*.css",

--- a/src/Dapp/dapp.js
+++ b/src/Dapp/dapp.js
@@ -146,6 +146,7 @@ export default class Dapp extends Component {
     const preload = `file://${path.join(
       posixDirName,
       '..',
+      '.build',
       'inject.js'
     )}`;
 

--- a/src/Dapp/dapp.js
+++ b/src/Dapp/dapp.js
@@ -20,6 +20,7 @@ import isElectron from 'is-electron';
 import { observer } from 'mobx-react';
 import PropTypes from 'prop-types';
 import path from 'path';
+import url from 'url';
 
 import builtinDapps from '@parity/shared/lib/config/dappsBuiltin.json';
 import viewsDapps from '@parity/shared/lib/config/dappsViews.json';
@@ -78,6 +79,17 @@ export default class Dapp extends Component {
     // Log console.logs from webview
     webview.addEventListener('console-message', e => {
       console.log('[DAPP]', e.message);
+    });
+
+    // Open all <a target="_blank"> in browser
+    webview.addEventListener('new-window', (e) => {
+      const protocol = url.parse(e.url).protocol;
+
+      if (protocol === 'http:' || protocol === 'https:') {
+        const { shell } = window.require('electron');
+
+        shell.openExternal(e.url);
+      }
     });
 
     // Reput eventListeners when webview has finished loading dapp

--- a/webpack/electron.js
+++ b/webpack/electron.js
@@ -32,8 +32,8 @@ module.exports = {
   context: path.join(__dirname, '../electron'),
   entry: './index.js',
   output: {
-    path: path.join(__dirname, '../', DEST, 'electron'),
-    filename: 'index.js'
+    path: path.join(__dirname, '../', DEST),
+    filename: 'electron.js'
   },
   node: {
     __dirname: false


### PR DESCRIPTION
To test: `npm run electron`, in the wallet, in any account, click on the Etherscan link.

Also small detail, changed webpack config so that it outputs `.build/electron.js` instead of `.build/electron/index.js`. If `npm run electron` works, everything should be fine.