### PR TITLE
Fix appId heuristics in inject.js

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -24,16 +24,19 @@ function getAppId () {
   // Dapps built into the shell; URL: file://path-to-shell/.build/dapps/0x0587.../index.html
   // Dapps installed from the registry and served by Parity; URL: http://127.0.0.1:8545/ff19...
   const [hash] = window.location.pathname.match(/(0x)?[a-f0-9]{64}/i) || [];
-  if (hash) return hash;
+
+  if (hash) { return hash; }
 
   // Dapps served in development mode on a dedicated port; URL: http://localhost:3001/?appId=dapp-name
   const fromQuery = qs.parse(window.location.search).appId;
-  if (fromQuery) return fromQuery;
+
+  if (fromQuery) { return fromQuery; }
 
   // Dapps built locally and served by Parity; URL: http://127.0.0.1:8545/dapp-name
   const [, fromParity] = window.location.pathname.match(/^\/?([^/]+)\/?$/) || [];
-  if (fromParity) return fromParity;
-  
+
+  if (fromParity) { return fromParity; }
+
   console.error('Could not find appId');
 }
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -24,14 +24,17 @@ function getAppId () {
   // Dapps built into the shell; URL: file://path-to-shell/.build/dapps/0x0587.../index.html
   // Dapps installed from the registry and served by Parity; URL: http://127.0.0.1:8545/ff19...
   const [hash] = window.location.pathname.match(/(0x)?[a-f0-9]{64}/i) || [];
+  if (hash) return hash;
 
   // Dapps served in development mode on a dedicated port; URL: http://localhost:3001/?appId=dapp-name
   const fromQuery = qs.parse(window.location.search).appId;
+  if (fromQuery) return fromQuery;
 
   // Dapps built locally and served by Parity; URL: http://127.0.0.1:8545/dapp-name
   const [, fromParity] = window.location.pathname.match(/^\/?([^/]+)\/?$/) || [];
-
-  return hash || fromQuery || fromParity;
+  if (fromParity) return fromParity;
+  
+  console.error('Could not find appId');
 }
 
 function initProvider () {


### PR DESCRIPTION
Previously appId was undefined for dapps built locally that were served by Parity.

I also noticed that currently the appId for hashes can either include `0x` or not (depending on how the dapp is served); I left it this way because otherwise known dapps would have to request their permissions again (with/without `0x`), but it might be worth normalizing this at some point.