### PR TITLE
Update to electron 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3543,6 +3543,12 @@
       "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo=",
       "dev": true
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
@@ -3553,6 +3559,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
       "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "buffer-indexof": {
@@ -6036,20 +6048,20 @@
       }
     },
     "electron": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.4.tgz",
-      "integrity": "sha512-2f1cx0G3riMFODXFftF5AHXy+oHfhpntZHTDN66Hxtl09gmEr42B3piNEod9MEmw72f75LX2JfeYceqq1PF8cA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.2.tgz",
+      "integrity": "sha512-XmkGVoHLOqmjZ2nU/0zEzMl3TZEz452Q1fTJFKjylg4pLYaq7na7V2uxzydVQNQukZGbERoA7ayjxXzTsXbtdA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.10",
+        "@types/node": "8.10.17",
         "electron-download": "3.3.0",
-        "extract-zip": "1.6.6"
+        "extract-zip": "1.6.7"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.10.tgz",
-          "integrity": "sha512-p3W/hFzQs76RlYRIZsZc5a9bht6m0TspmWYYbKhRswmLnwj9fsE40EbuGifeu/XWR/c0UJQ1DDbvTxIsm/OOAA==",
+          "version": "8.10.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
+          "integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg==",
           "dev": true
         }
       }
@@ -6401,7 +6413,7 @@
       "requires": {
         "debug": "2.6.9",
         "fs-extra": "0.30.0",
-        "home-path": "1.0.5",
+        "home-path": "1.0.6",
         "minimist": "1.2.0",
         "nugget": "2.0.1",
         "path-exists": "2.1.0",
@@ -7935,24 +7947,36 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "yauzl": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+          "dev": true,
+          "requires": {
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -10249,9 +10273,9 @@
       }
     },
     "home-path": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
+      "integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==",
       "dev": true
     },
     "homedir-polyfill": {
@@ -15158,7 +15182,7 @@
       "dev": true,
       "requires": {
         "es6-promise": "4.1.1",
-        "extract-zip": "1.6.6",
+        "extract-zip": "1.6.7",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
         "kew": "0.7.0",
@@ -23060,11 +23084,12 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
+        "buffer-crc32": "0.2.13",
         "fd-slicer": "1.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "cross-env": "5.1.1",
     "css-loader": "0.28.4",
     "ejs-loader": "0.3.0",
-    "electron": "1.8.4",
+    "electron": "2.0.2",
     "electron-builder": "20.10.0",
     "empty-module": "0.0.2",
     "enzyme": "3.2.0",
@@ -152,7 +152,8 @@
     "webpack-error-notification": "0.1.6",
     "webpack-hot-middleware": "2.17.1",
     "websocket": "1.0.24",
-    "worker-loader": "1.1.1"
+    "worker-loader": "1.1.1",
+    "yauzl": "2.9.1"
   },
   "dependencies": {
     "@parity/api": "2.1.20",

--- a/src/Dapp/dapp.js
+++ b/src/Dapp/dapp.js
@@ -142,7 +142,7 @@ export default class Dapp extends Component {
     return <webview
       className={ styles.frame }
       id='dappFrame'
-      nodeintegration='true'
+      nodeintegration='false'
       preload={ preload }
       ref={ this.handleWebview }
       src={ `${src}${hash}` }


### PR DESCRIPTION
@devops-parity pointed out [this article](https://www.trustwave.com/Resources/SpiderLabs-Blog/CVE-2018-1000136---Electron-nodeIntegration-Bypass/?_gclid=5b009a9caccdd5.68822352-5b009a9cacce59.61250057&_utm_source=xakep&_utm_campaign=mention167843&_utm_medium=inline&_utm_content=lnk739253583705) which introduces an attack vector to access all node.js capabilities if a malicious external dapp is loaded via webview.

So we:
- disable nodeintegration for all dapps (should have been disabled since the beginning)
- update electron to 2.0.2 where they fixed this issue

To be backported to stable and beta