### PR TITLE
Parse and load local dapps directly from filesystem

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -15,8 +15,10 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 const electron = require('electron');
+const fs = require('fs');
 const path = require('path');
 const url = require('url');
+const util = require('util');
 
 const addMenu = require('./menu');
 const { cli } = require('./cli');
@@ -25,8 +27,12 @@ const fetchParity = require('./operations/fetchParity');
 const handleError = require('./operations/handleError');
 const messages = require('./messages');
 const { killParity } = require('./operations/runParity');
+const { getLocalDappsPath } = require('../src/util/host');
 
 const { app, BrowserWindow, ipcMain, session } = electron;
+
+const fsExists = util.promisify(fs.stat); // eslint-disable-line
+const fsMkdir = util.promisify(fs.mkdir);
 
 let mainWindow;
 
@@ -40,6 +46,11 @@ function createWindow () {
     height: 800,
     width: 1200
   });
+
+  const localDappsPath = getLocalDappsPath();
+
+  fsExists(localDappsPath)
+    .catch(() => fsMkdir(localDappsPath));
 
   doesParityExist()
     .catch(() => fetchParity(mainWindow)) // Install parity if not present

--- a/electron/index.js
+++ b/electron/index.js
@@ -27,7 +27,7 @@ const fetchParity = require('./operations/fetchParity');
 const handleError = require('./operations/handleError');
 const messages = require('./messages');
 const { killParity } = require('./operations/runParity');
-const { getLocalDappsPath } = require('../src/util/host');
+const { getLocalDappsPath } = require('./utils/paths');
 
 const { app, BrowserWindow, ipcMain, session } = electron;
 

--- a/electron/index.js
+++ b/electron/index.js
@@ -27,6 +27,7 @@ const messages = require('./messages');
 const { killParity } = require('./operations/runParity');
 
 const { app, BrowserWindow, ipcMain, session } = electron;
+
 let mainWindow;
 
 function createWindow () {
@@ -128,3 +129,5 @@ app.on('activate', () => {
     createWindow();
   }
 });
+
+app.setPath('userData', path.join(app.getPath('appData'), 'Parity-UI'));

--- a/electron/index.js
+++ b/electron/index.js
@@ -28,6 +28,7 @@ const handleError = require('./operations/handleError');
 const messages = require('./messages');
 const { killParity } = require('./operations/runParity');
 const { getLocalDappsPath } = require('./utils/paths');
+const { name: appName } = require('../package.json');
 
 const { app, BrowserWindow, ipcMain, session } = electron;
 
@@ -141,4 +142,9 @@ app.on('activate', () => {
   }
 });
 
-app.setPath('userData', path.join(app.getPath('appData'), 'Parity-UI'));
+// userData value is derived from the Electron app name by default. However,
+// Electron doesn't know the app name defined in package.json because we
+// execute Electron directly on a file. Running Electron on a folder (either
+// .build/ or electron/) doesn't solve the issue because the package.json
+// is located in the parent directory.
+app.setPath('userData', path.join(app.getPath('appData'), appName));

--- a/electron/utils/parityPath.js
+++ b/electron/utils/parityPath.js
@@ -16,10 +16,11 @@
 
 const { app } = require('electron');
 
-const parityPath = `${app.getPath('userData')}/parity${process.platform === 'win32' ? '.exe' : ''}`;
-
 // TODO parityPath is now in the Application Data folder by default, it would
 // be nice to first look if /usr/bin/parity exists (and return that as
 // parityPath). For now we keep Application Data as parityPath.
 // See https://github.com/parity-js/shell/issues/66
-module.exports = () => parityPath;
+
+// We cannot use app.getPath('userData') outside of the exports because
+// it would then be executed before app.setPath('userData') in index.js
+module.exports = () => `${app.getPath('userData')}/parity${process.platform === 'win32' ? '.exe' : ''}`;

--- a/electron/utils/paths.js
+++ b/electron/utils/paths.js
@@ -1,0 +1,26 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+const path = require('path');
+const electron = require('electron');
+
+module.exports = {
+  getLocalDappsPath: () => {
+    const userData = electron.app.getPath('userData');
+
+    return path.join(userData, 'dapps');
+  }
+};

--- a/src/Dapp/dapp.js
+++ b/src/Dapp/dapp.js
@@ -174,9 +174,7 @@ export default class Dapp extends Component {
 
     switch (app.type) {
       case 'local':
-        src = app.localUrl
-          ? `${app.localUrl}?appId=${app.id}`
-          : `${dappsUrl}/${app.id}/`;
+        src = `${app.localUrl}?appId=${app.id}`;
         break;
 
       case 'network':

--- a/src/Dapp/dapp.js
+++ b/src/Dapp/dapp.js
@@ -174,27 +174,12 @@ export default class Dapp extends Component {
 
     switch (app.type) {
       case 'local':
+      case 'builtin':
         src = `${app.localUrl}?appId=${app.id}`;
         break;
 
       case 'network':
         src = `${dappsUrl}/${app.contentHash}/`;
-        break;
-
-      default:
-        let dapphost = process.env.DAPPS_URL || (
-          process.env.NODE_ENV === 'production'
-            ? `${dappsUrl}/ui`
-            : ''
-        );
-
-        if (dapphost === '/') {
-          dapphost = '';
-        }
-
-        src = window.location.protocol === 'file:'
-          ? `dapps/${app.id}/index.html`
-          : `${dapphost}/dapps/${app.id}/index.html`;
         break;
     }
 

--- a/src/Dapps/dappsBuiltin.json
+++ b/src/Dapps/dappsBuiltin.json
@@ -1,7 +1,6 @@
 [
   {
     "id": "v1",
-    "url": "v1",
     "name": "Parity Wallet",
     "package": "@parity/dapp-wallet",
     "description": "Parity Wallet and Account management tools",
@@ -11,7 +10,6 @@
   },
   {
     "id": "0x889d3403834b4ef359448575dcd6d77334330edaecc66a77051483f3a498ab6e",
-    "url": "dappMethods",
     "src": "DappMethods",
     "name": "Dapp Method Permissions",
     "package": "@parity/dapp-dapp-methods",
@@ -22,7 +20,6 @@
   },
   {
     "id": "0xa48bd8fd56c90c899135281967a6cf90865c221b46f27f9fbe2a236d74a64ea2",
-    "url": "dappVisible",
     "src": "DappVisible",
     "name": "Browse Dapps",
     "package": "@parity/dapp-dapp-visible",
@@ -33,7 +30,6 @@
   },
   {
     "id": "0xcd423760c9650eb549b1615f6cf96d420e32aadcea2ff5fe11c26457244adcc1",
-    "url": "status",
     "src": "Status",
     "name": "Node Status",
     "package": "@parity/dapp-status",
@@ -44,7 +40,6 @@
   },
   {
     "id": "0x89682fd2c0ffa4ff53a8dc2c5f6a65c6e31de8f659fa2935a07a678e711a58a3",
-    "url": "develop",
     "src": "Develop",
     "name": "Develop Contracts",
     "package": "@parity/dapp-develop",
@@ -54,7 +49,6 @@
     "visible": true
   },
   {
-    "url": "chaindeploy",
     "name": "Chain Deployment",
     "package": "@parity/dapp-chaindeploy",
     "description": "Deploy all basic contracts, names & applications to the network",
@@ -65,7 +59,6 @@
   },
   {
     "id": "0xa635a9326814bded464190eddf0bdb90ce92d40ea2359cf553ea80e3c5a4076c",
-    "url": "console",
     "name": "Parity/Web3 console",
     "package": "@parity/dapp-console",
     "description": "A Javascript development console complete with web3 and parity objects",
@@ -76,7 +69,6 @@
   },
   {
     "id": "0xf9f2d620c2e08f83e45555247146c62185e4ab7cf82a4b9002a265a0d020348f",
-    "url": "tokendeploy",
     "name": "Token Deployment",
     "package": "@parity/dapp-tokendeploy",
     "description": "Deploy new basic tokens that you are able to send around",
@@ -86,7 +78,6 @@
   },
   {
     "id": "0xd1adaede68d344519025e2ff574650cd99d3830fe6d274c7a7843cdc00e17938",
-    "url": "registry",
     "name": "Registry",
     "package": "@parity/dapp-registry",
     "description": "A global registry of addresses on the network",
@@ -96,7 +87,6 @@
   },
   {
     "id": "0x0a8048117e51e964628d0f2d26342b3cd915248b59bcce2721e1d05f5cfa2208",
-    "url": "tokenreg",
     "name": "Token Registry",
     "package": "@parity/dapp-tokenreg",
     "description": "A registry of transactable tokens on the network",
@@ -106,7 +96,6 @@
   },
   {
     "id": "0xf49089046f53f5d2e5f3513c1c32f5ff57d986e46309a42d2b249070e4e72c46",
-    "url": "signaturereg",
     "name": "Method Registry",
     "package": "@parity/dapp-signaturereg",
     "description": "A registry of method signatures for lookups on transactions",
@@ -116,7 +105,6 @@
   },
   {
     "id": "0x058740ee9a5a3fb9f1cfa10752baec87e09cc45cd7027fd54708271aca300c75",
-    "url": "githubhint",
     "name": "GitHub Hint",
     "package": "@parity/dapp-githubhint",
     "description": "A mapping of GitHub URLs to hashes for use in contracts as references",
@@ -127,7 +115,6 @@
   },
   {
     "id": "0xae74ad174b95cdbd01c88ac5b73a296d33e9088fc2a200e76bcedf3a94a7815d",
-    "url": "localtx",
     "name": "TxQueue Viewer",
     "package": "@parity/dapp-localtx",
     "description": "Have a peek at the internals of your node's transaction queue",
@@ -137,7 +124,6 @@
   },
   {
     "id": "0x7bbc4f1a27628781b96213e781a1b8eec6982c1db8fac739af6e4c5a55862c03",
-    "url": "dappreg",
     "name": "Dapp Registration",
     "package": "@parity/dapp-dappreg",
     "description": "Enables the registration and content management of dapps on the network",

--- a/src/Dapps/store.js
+++ b/src/Dapps/store.js
@@ -191,7 +191,7 @@ export default class DappsStore extends EventEmitter {
   }
 
   fetchLocalApps () {
-    return fetchLocalApps(this._api);
+    return fetchLocalApps();
   }
 
   fetchRegistryAppIds (force = false) {

--- a/src/Dapps/store.js
+++ b/src/Dapps/store.js
@@ -181,7 +181,7 @@ export default class DappsStore extends EventEmitter {
       return Promise.resolve(this._cachedApps[BUILTIN_APPS_KEY]);
     }
 
-    this._cachedApps[BUILTIN_APPS_KEY] = fetchBuiltinApps(this._api)
+    this._cachedApps[BUILTIN_APPS_KEY] = fetchBuiltinApps()
       .then((apps) => {
         this._cachedApps[BUILTIN_APPS_KEY] = apps;
         return apps;

--- a/src/inject.js
+++ b/src/inject.js
@@ -18,6 +18,12 @@ import Api from '@parity/api';
 import qs from 'query-string';
 
 function getAppId () {
+  // Local dapps: file:///home/username/.config/Parity-UI/dapps/mydapp/index.html?appId=LOCAL-dapp-name
+  // Local dapps served in development mode on a dedicated port: http://localhost:3001/?appId=LOCAL-dapp-name
+  const fromQuery = qs.parse(window.location.search).appId;
+
+  if (fromQuery) { return fromQuery; }
+
   // Built-in dapps: file://path-to-shell/.build/dapps/0x0587.../index.html
   // Built-in dapps when running Electron in dev mode: http://127.0.0.1:3000/dapps/v1/index.html
   const [, id] = window.location.pathname.match(/dapps\/([^/]+)\//) || [];
@@ -28,16 +34,6 @@ function getAppId () {
   const [hash] = window.location.pathname.match(/(0x)?[a-f0-9]{64}/i) || [];
 
   if (hash) { return hash; }
-
-  // Dapps served in development mode on a dedicated port: http://localhost:3001/?appId=dapp-name
-  const fromQuery = qs.parse(window.location.search).appId;
-
-  if (fromQuery) { return fromQuery; }
-
-  // Dapps built locally and served by Parity: http://127.0.0.1:8545/dapp-name
-  const [, fromParity] = window.location.pathname.match(/^\/?([^/]+)\/?$/) || [];
-
-  if (fromParity) { return fromParity; }
 
   console.error('Could not find appId');
 }

--- a/src/inject.js
+++ b/src/inject.js
@@ -20,15 +20,11 @@ import qs from 'query-string';
 function getAppId () {
   // Local dapps: file:///home/username/.config/Parity-UI/dapps/mydapp/index.html?appId=LOCAL-dapp-name
   // Local dapps served in development mode on a dedicated port: http://localhost:3001/?appId=LOCAL-dapp-name
+  // Built-in dapps: file://path-to-shell/.build/dapps/0x0587.../index.html?appId=dapp-name
+  // Built-in dapps when running Electron in dev mode: http://127.0.0.1:3000/dapps/v1/index.html?appId=dapp-name
   const fromQuery = qs.parse(window.location.search).appId;
 
   if (fromQuery) { return fromQuery; }
-
-  // Built-in dapps: file://path-to-shell/.build/dapps/0x0587.../index.html
-  // Built-in dapps when running Electron in dev mode: http://127.0.0.1:3000/dapps/v1/index.html
-  const [, id] = window.location.pathname.match(/dapps\/([^/]+)\//) || [];
-
-  if (id) { return id; }
 
   // Dapps installed from the registry and served by Parity: http://127.0.0.1:8545/ff19...
   const [hash] = window.location.pathname.match(/(0x)?[a-f0-9]{64}/i) || [];

--- a/src/util/dapps.js
+++ b/src/util/dapps.js
@@ -27,8 +27,6 @@ import Contracts from '@parity/shared/lib/contracts';
 
 import path from 'path';
 
-const electron = window.require('electron');
-
 const util = isElectron() ? window.require('util') : require('util');
 
 require('util.promisify').shim();

--- a/src/util/dapps.js
+++ b/src/util/dapps.js
@@ -83,7 +83,7 @@ export function subscribeToChanges (api, dappReg, callback) {
     });
 }
 
-export function fetchBuiltinApps (api) {
+export function fetchBuiltinApps () {
   const initialApps = builtinApps.filter(app => app.id);
 
   const builtinDappsPath = path.join(
@@ -128,7 +128,7 @@ export function fetchBuiltinApps (api) {
     });
 }
 
-export function fetchLocalApps (api) {
+export function fetchLocalApps () {
   const dappsPath = getLocalDappsPath();
 
   return fsReaddir(dappsPath) // List files

--- a/src/util/dapps.js
+++ b/src/util/dapps.js
@@ -120,11 +120,8 @@ export function fetchBuiltinApps (api) {
           const iconUrl = manifests[index].iconUrl || 'icon.png';
 
           app.type = 'builtin';
-          app.image = `file://${path.join(
-            builtinDappsPath,
-            app.id,
-            iconUrl
-          )}`;
+          app.localUrl = `file://${builtinDappsPath}/${app.id}/index.html`;
+          app.image = `file://${builtinDappsPath}/${app.id}/${iconUrl}`;
 
           return app;
         });

--- a/src/util/dapps.js
+++ b/src/util/dapps.js
@@ -19,7 +19,7 @@ import { pick, range, uniq } from 'lodash';
 
 import { bytesToHex } from '@parity/api/lib/util/format';
 import { IconCache } from '@parity/ui';
-import { getBuildPath } from './host';
+import { getBuildPath, getLocalDappsPath } from './host';
 import isElectron from 'is-electron';
 
 import builtinApps from '../Dapps/dappsBuiltin.json';
@@ -27,12 +27,16 @@ import Contracts from '@parity/shared/lib/contracts';
 
 import path from 'path';
 
+const electron = window.require('electron');
+
 const util = isElectron() ? window.require('util') : require('util');
 
 require('util.promisify').shim();
 
 const fs = isElectron() ? window.require('fs') : require('fs');
-const fsReadFileAsync = util.promisify(fs.readFile);
+const fsReadFile = util.promisify(fs.readFile);
+const fsReaddir = util.promisify(fs.readdir);
+const fsStat = util.promisify(fs.stat);
 
 export function subscribeToChanges (api, dappReg, callback) {
   return dappReg
@@ -98,7 +102,7 @@ export function fetchBuiltinApps (api) {
       );
 
       if (fs.existsSync(manifestPath)) {
-        return fsReadFileAsync(manifestPath).then(r => {
+        return fsReadFile(manifestPath).then(r => {
           try {
             return JSON.parse(r);
           } catch (e) {
@@ -128,16 +132,48 @@ export function fetchBuiltinApps (api) {
 }
 
 export function fetchLocalApps (api) {
-  return api.parity.dappsList()
-    .then((apps) => {
-      return apps
-        .map((app) => {
-          app.type = 'local';
-          app.visible = true;
-          return app;
-        })
-        .filter((app) => app.id && !['ui'].includes(app.id));
-    })
+  const dappsPath = getLocalDappsPath();
+
+  return fsReaddir(dappsPath) // List files
+    .then(filenames => // Gather info about files
+      Promise.all(filenames.map(filename => {
+        const filePath = path.join(dappsPath, filename);
+
+        return fsStat(filePath).then(stat => ({ isDirectory: stat.isDirectory(), filePath, filename }));
+      }))
+    )
+    .then(files => // Only keep directories
+      files.filter(({ isDirectory }) => isDirectory))
+    .then(dappsFolders => // Parse manifests
+      Promise.all(dappsFolders.map(({ filePath, filename }) => {
+        const manifestPath = path.join(filePath, 'manifest.json');
+
+        if (fs.existsSync(manifestPath)) {
+          return fsReadFile(manifestPath).then(r => {
+            try {
+              return { filename, manifest: JSON.parse(r) };
+            } catch (e) {
+              console.error(`Couldn't parse manifest.json for local dapp ${filePath}`, e);
+              return { filename };
+            }
+          });
+        } else {
+          console.error(`No manifest.json found for local dapp ${filePath}`);
+          return { filename };
+        }
+      })))
+    .then(dapps =>
+      dapps.filter(({ manifest }) => manifest))
+    .then(dapps =>
+      dapps.map(({ filename, manifest: { id, localUrl, ...rest } }) => (
+        {
+          ...rest,
+          type: 'local',
+          id: `LOCAL-${id}`, // Prevent appId spoofing
+          visible: true,
+          localUrl: localUrl || `file://${dappsPath}/${filename}/index.html`
+        }
+    )))
     .catch((error) => {
       console.warn('DappsStore:fetchLocal', error);
     });

--- a/src/util/dapps.js
+++ b/src/util/dapps.js
@@ -165,13 +165,15 @@ export function fetchLocalApps (api) {
     .then(dapps =>
       dapps.filter(({ manifest }) => manifest))
     .then(dapps =>
-      dapps.map(({ filename, manifest: { id, localUrl, ...rest } }) => (
+      dapps.map(({ filename, manifest: { id, localUrl, iconUrl, ...rest } }) => (
         {
           ...rest,
           type: 'local',
-          id: `LOCAL-${id}`, // Prevent appId spoofing
+          // Prevent using the appId of an existing non-local dapp with already approved permissions
+          id: `LOCAL-${id}`,
           visible: true,
-          localUrl: localUrl || `file://${dappsPath}/${filename}/index.html`
+          localUrl: localUrl || `file://${dappsPath}/${filename}/index.html`,
+          image: `file://${dappsPath}/${filename}/${iconUrl}`
         }
     )))
     .catch((error) => {

--- a/src/util/host.js
+++ b/src/util/host.js
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import isElectron from 'is-electron';
-import path from 'path';
+const path = require('path');
 
-export function createLocation (token, location = window.location) {
+function createLocation (token, location = window.location) {
   const { hash, port, protocol } = location;
   let query = '';
 
@@ -31,7 +30,7 @@ export function createLocation (token, location = window.location) {
   return `${protocol}//127.0.0.1:${port}/${query}`;
 }
 
-export function redirectLocalhost (token) {
+function redirectLocalhost (token) {
   // we don't want localhost, rather we want 127.0.0.1
   if (window.location.hostname !== 'localhost') {
     return false;
@@ -42,8 +41,8 @@ export function redirectLocalhost (token) {
   return true;
 }
 
-export function getBuildPath () {
-  const basePath = isElectron() ? window.require('electron').remote.getGlobal('dirName') : path.join(__dirname, '..');
+function getBuildPath () {
+  const basePath = window.require('electron').remote.getGlobal('dirName');
 
   // Replace all backslashes by front-slashes (happens in Windows)
   // Note: `dirName` contains backslashes in Windows. One would assume that
@@ -58,3 +57,22 @@ export function getBuildPath () {
 
   return buildPath;
 }
+
+function getLocalDappsPath () {
+  // FIXME
+  const userData = typeof window !== 'undefined'
+    ? window.require('electron').remote.app.getPath('userData')
+    : require('electron').app.getPath('userData');
+
+  return path.join(userData, 'dapps');
+}
+
+// FIXME
+// Need to find a better way to be able to import this file
+// from electron/ as well as src/
+module.exports = {
+  createLocation,
+  redirectLocalhost,
+  getBuildPath,
+  getLocalDappsPath
+};

--- a/src/util/host.js
+++ b/src/util/host.js
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-const path = require('path');
+import path from 'path';
 
-function createLocation (token, location = window.location) {
+export function createLocation (token, location = window.location) {
   const { hash, port, protocol } = location;
   let query = '';
 
@@ -30,7 +30,7 @@ function createLocation (token, location = window.location) {
   return `${protocol}//127.0.0.1:${port}/${query}`;
 }
 
-function redirectLocalhost (token) {
+export function redirectLocalhost (token) {
   // we don't want localhost, rather we want 127.0.0.1
   if (window.location.hostname !== 'localhost') {
     return false;
@@ -41,7 +41,7 @@ function redirectLocalhost (token) {
   return true;
 }
 
-function getBuildPath () {
+export function getBuildPath () {
   const basePath = window.require('electron').remote.getGlobal('dirName');
 
   // Replace all backslashes by front-slashes (happens in Windows)
@@ -58,21 +58,8 @@ function getBuildPath () {
   return buildPath;
 }
 
-function getLocalDappsPath () {
-  // FIXME
-  const userData = typeof window !== 'undefined'
-    ? window.require('electron').remote.app.getPath('userData')
-    : require('electron').app.getPath('userData');
+export function getLocalDappsPath () {
+  const userData = window.require('electron').remote.app.getPath('userData');
 
   return path.join(userData, 'dapps');
 }
-
-// FIXME
-// Need to find a better way to be able to import this file
-// from electron/ as well as src/
-module.exports = {
-  createLocation,
-  redirectLocalhost,
-  getBuildPath,
-  getLocalDappsPath
-};

--- a/src/util/host.js
+++ b/src/util/host.js
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import path from 'path';
+import isElectron from 'is-electron';
 
 export function createLocation (token, location = window.location) {
   const { hash, port, protocol } = location;
@@ -42,7 +43,10 @@ export function redirectLocalhost (token) {
 }
 
 export function getBuildPath () {
-  const basePath = window.require('electron').remote.getGlobal('dirName');
+  // Condition necessary for store.spec.js
+  const basePath = isElectron()
+    ? window.require('electron').remote.getGlobal('dirName')
+    : path.join(__dirname, '..');
 
   // Replace all backslashes by front-slashes (happens in Windows)
   // Note: `dirName` contains backslashes in Windows. One would assume that
@@ -59,7 +63,10 @@ export function getBuildPath () {
 }
 
 export function getLocalDappsPath () {
-  const userData = window.require('electron').remote.app.getPath('userData');
+  // Condition necessary for store.spec.js
+  const userData = isElectron()
+    ? window.require('electron').remote.app.getPath('userData')
+    : path.join(__dirname, 'dapps');
 
   return path.join(userData, 'dapps');
 }


### PR DESCRIPTION
Local dapps are now located in `~/.config/Parity-UI/dapps/`. Local dapps served by Parity are ignored and need to be moved to this new location.

Prevent local dapps from using the appId of a non-local dapp (for which the user might already have approved permissions): `{"id": "v1"}` is inconspicuous. Local dapps ids are now prefixed with `LOCAL-` (caps to prevent accidental use of the prefix when naming one's dapp).