### PR TITLE
Remove call to /api/ping

### DIFF
--- a/src/secureApi.js
+++ b/src/secureApi.js
@@ -165,7 +165,7 @@ export default class SecureApi extends Api {
    * otherwise (HEAD request to the Node)
    */
   isNodeUp () {
-    return fetch(`${this.protocol()}//${this._wsUrl}/api/ping`, { method: 'HEAD', mode: 'no-cors' })
+    return fetch(`${this.protocol()}//${this._wsUrl}`, { method: 'HEAD', mode: 'no-cors' })
       .then(() => true)
       .catch(() => false);
   }


### PR DESCRIPTION
/api/ping will be removed when dapps gets removed from Parity.

Just tested:
- `curl -X HEAD 127.0.0.1:8546` returns something when Parity is running
- `curl -X HEAD 127.0.0.1:8546` returns nothing when Parity is off.

Working inside the UI as well, by turning on/off Parity.

@axelchalon Would like you to test too, just to be sure.