### PR TITLE
Fix fetchParity(mainWindow) race condition

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -17,7 +17,6 @@
 const electron = require('electron');
 const path = require('path');
 const url = require('url');
-const { ensureDir: fsEnsureDir } = require('fs-extra');
 
 const addMenu = require('./menu');
 const { cli } = require('./cli');
@@ -38,14 +37,6 @@ let mainWindow;
 // https://github.com/parity-js/shell/issues/157
 if (!['darwin', 'win32'].includes(process.platform)) {
   app.disableHardwareAcceleration();
-}
-
-function runApp () {
-  doesParityExist()
-    .catch(() => fetchParity(mainWindow)) // Install parity if not present
-    .catch(handleError); // Errors should be handled before, this is really just in case
-
-  return fsEnsureDir(getLocalDappsPath()).then(createWindow);
 }
 
 function createWindow () {
@@ -74,6 +65,10 @@ function createWindow () {
       })
     );
   }
+
+  doesParityExist()
+    .catch(() => fetchParity(mainWindow)) // Install parity if not present
+    .catch(handleError); // Errors should be handled before, this is really just in case
 
   // Listen to messages from renderer process
   ipcMain.on('asynchronous-message', messages);
@@ -179,7 +174,7 @@ function createWindow () {
   });
 }
 
-app.on('ready', runApp);
+app.on('ready', createWindow);
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/src/util/dapps.js
+++ b/src/util/dapps.js
@@ -171,7 +171,7 @@ export function fetchLocalApps () {
           localUrl: localUrl || `file://${dappsPath}/${filename}/index.html`,
           image: `file://${dappsPath}/${filename}/${iconUrl}`
         }
-    )))
+      )))
     .catch((error) => {
       console.warn('DappsStore:fetchLocal', error);
     });
@@ -253,7 +253,7 @@ export function fetchRegistryApp (api, dappReg, appId) {
           })
       );
     })
-      .catch((error) => {
-        console.warn('DappsStore:fetchRegistryApp', appId, error);
-      });
+    .catch((error) => {
+      console.warn('DappsStore:fetchRegistryApp', appId, error);
+    });
 }

--- a/src/util/dapps.js
+++ b/src/util/dapps.js
@@ -31,6 +31,7 @@ const util = require('util');
 require('util.promisify').shim();
 
 const fs = require('fs');
+const { ensureDir: fsEnsureDir } = require('fs-extra');
 const fsReadFile = util.promisify(fs.readFile);
 const fsReaddir = util.promisify(fs.readdir);
 const fsStat = util.promisify(fs.stat);
@@ -130,7 +131,8 @@ export function fetchBuiltinApps () {
 export function fetchLocalApps () {
   const dappsPath = getLocalDappsPath();
 
-  return fsReaddir(dappsPath) // List files
+  return fsEnsureDir(dappsPath)
+    .then(() => fsReaddir(dappsPath)) // List files
     .then(filenames => // Gather info about files
       Promise.all(filenames.map(filename => {
         const filePath = path.join(dappsPath, filename);


### PR DESCRIPTION
Previously, `fetchParity` was called with `mainWindow` as argument but we had no guarantee that `mainWindow` was defined at that time.
