### PR TITLE
[BETA] Use persistent storage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,3 +103,4 @@ publish:snap:
     - scripts/publish-snap.sh
   tags:
     - rust-stable
+#gitsync enabled

--- a/electron/index.js
+++ b/electron/index.js
@@ -111,6 +111,7 @@ function createWindow () {
 
     let baseUrl;
     let appId;
+    let token;
 
     // Derive the dapp baseUrl (.../my-dapp/) from the first URL of the webview
     // (.../my-dapp/index.html). The baseUrl defines what files the webview is
@@ -120,7 +121,8 @@ function createWindow () {
     webContents.once('did-navigate', (e, initialUrl) => {
       const initialURL = new URL(initialUrl);
 
-      appId = initialURL.searchParams.get('appId');
+      appId = initialURL.searchParams.get('shellAppId');
+      token = initialURL.searchParams.get('shellToken');
 
       initialURL.hash = '';
       initialURL.search = '';
@@ -138,7 +140,8 @@ function createWindow () {
 
         const newURL = new URL(targetUrl);
 
-        newURL.searchParams.set('appId', appId);
+        newURL.searchParams.set('shellAppId', appId);
+        newURL.searchParams.set('shellToken', token);
 
         webContents.loadURL(newURL.href);
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.3.tgz",
       "integrity": "sha512-FETrNnu9+uQiICpCpFIDidesWYS4ditXvGn/zjVZunlPXCdX4HbBzHECSNbaULzZOBO+AV+CC/Qf/zITaf78Lw==",
+      "dev": true,
       "requires": {
         "bignumber.js": "3.0.1",
         "js-sha3": "0.5.5",
@@ -216,19 +217,20 @@
         "js-sha3": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
         }
       }
     },
     "@parity/api": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@parity/api/-/api-2.1.20.tgz",
-      "integrity": "sha512-kl50p0644oDp13zlsu5VmuhstUa4CrgcZQOV+ybQ8cnXT3eVD743S0a5zC9n8Y4RJbLxHUsM7oDkbTG3cj+/OA==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@parity/api/-/api-2.1.24.tgz",
+      "integrity": "sha512-jJ93cyC5eZC9pQY/FXcSyQiFHNzg5wFzrVLB+RVfbKbIqCWmOAhlv+rssN35qPZ4ccehIGgFB5i7rkpfSajzkQ==",
       "requires": {
-        "@parity/abi": "2.1.x",
+        "@parity/abi": "~2.1.4",
         "@parity/jsonrpc": "2.1.x",
         "@parity/wordlist": "1.1.x",
-        "bignumber.js": "3.0.1",
+        "bignumber.js": "4.1.0",
         "blockies": "0.0.2",
         "es6-error": "4.0.2",
         "es6-promise": "^4.1.1",
@@ -240,6 +242,21 @@
         "websocket": "^1.0.25"
       },
       "dependencies": {
+        "@parity/abi": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@parity/abi/-/abi-2.1.4.tgz",
+          "integrity": "sha512-4yPqCYXlLhb9jmmAg+0SkA/2Rmf1ZvPzmGF3WBKvgrAjWPAvj5hZYW5rquRqrP3L22KfG+7A9RAw3aZYp45AMQ==",
+          "requires": {
+            "bignumber.js": "4.1.0",
+            "js-sha3": "0.5.5",
+            "utf8": "^2.1.2"
+          }
+        },
+        "bignumber.js": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+          "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+        },
         "js-sha3": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
@@ -251,9 +268,9 @@
           "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM="
         },
         "websocket": {
-          "version": "1.0.25",
-          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.25.tgz",
-          "integrity": "sha512-M58njvi6ZxVb5k7kpnHh2BvNKuBWiwIYvsToErBzWhvBZYwlEiLcyLrG41T1jRcrY9ettqPYEqduLI7ul54CVQ==",
+          "version": "1.0.26",
+          "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
+          "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",
@@ -526,7 +543,6 @@
             "redux-actions": "1.1.0",
             "redux-thunk": "2.1.0",
             "scryptsy": "2.0.0",
-            "solc": "github:ngotchac/solc-js#04eb38cc3003fba8cb3656653a7941ed36408818",
             "useragent.js": "^0.5.6",
             "yargs": "6.6.0"
           },
@@ -534,20 +550,17 @@
             "ansi-regex": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "camelcase": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-              "dev": true
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
             },
             "find-up": {
               "version": "1.1.2",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -557,7 +570,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -566,7 +578,6 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
               "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -594,7 +605,6 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-              "dev": true,
               "requires": {
                 "lcid": "^1.0.0"
               }
@@ -603,7 +613,6 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
               "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -626,7 +635,6 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
               "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-              "dev": true,
               "requires": {
                 "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -637,7 +645,6 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-              "dev": true,
               "requires": {
                 "find-up": "^1.0.0",
                 "read-pkg": "^1.0.0"
@@ -645,8 +652,7 @@
             },
             "solc": {
               "version": "github:ngotchac/solc-js#04eb38cc3003fba8cb3656653a7941ed36408818",
-              "from": "github:ngotchac/solc-js",
-              "dev": true,
+              "from": "github:ngotchac/solc-js#04eb38cc3003fba8cb3656653a7941ed36408818",
               "requires": {
                 "memorystream": "^0.3.1",
                 "require-from-string": "^1.1.0",
@@ -657,7 +663,6 @@
                   "version": "4.8.1",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
                   "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-                  "dev": true,
                   "requires": {
                     "cliui": "^3.2.0",
                     "decamelize": "^1.1.1",
@@ -681,7 +686,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -692,7 +696,6 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -701,7 +704,6 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-              "dev": true,
               "requires": {
                 "is-utf8": "^0.2.0"
               }
@@ -709,14 +711,12 @@
             "which-module": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-              "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-              "dev": true
+              "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
             },
             "yargs-parser": {
               "version": "2.4.1",
               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
               "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-              "dev": true,
               "requires": {
                 "camelcase": "^3.0.0",
                 "lodash.assign": "^4.0.6"
@@ -1673,6 +1673,10 @@
           "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
           "dev": true
         },
+        "jsqr": {
+          "version": "git+https://github.com/JodusNodus/jsQR.git#5ba1acefa1cbb9b2bc92b49f503f2674e2ec212b",
+          "from": "git+https://github.com/JodusNodus/jsQR.git#5ba1acefa1cbb9b2bc92b49f503f2674e2ec212b"
+        },
         "keythereum": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/keythereum/-/keythereum-0.4.6.tgz",
@@ -1870,7 +1874,6 @@
           "integrity": "sha512-ruBF8KaSwUW9nbzjO4rA7/HOCGYZuNUz9od7uBRy8SRBi24nwxWWmwa2z8R6vPGDRglA0y2Qk1aVBuC1olTnHw==",
           "dev": true,
           "requires": {
-            "jsqr": "git+https://github.com/JodusNodus/jsQR.git#5ba1acefa1cbb9b2bc92b49f503f2674e2ec212b",
             "prop-types": "^15.5.8",
             "webrtc-adapter": "^2.0.8"
           }
@@ -14244,11 +14247,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "jsqr": {
-      "version": "git+https://github.com/JodusNodus/jsQR.git#5ba1acefa1cbb9b2bc92b49f503f2674e2ec212b",
-      "from": "git+https://github.com/JodusNodus/jsQR.git",
-      "dev": true
     },
     "jsx-ast-utils": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "yauzl": "2.9.1"
   },
   "dependencies": {
-    "@parity/api": "2.1.20",
+    "@parity/api": "2.1.24",
     "@parity/mobx": "1.1.2",
     "@parity/plugin-signer-account": "github:parity-js/plugin-signer-account#05294dce59b7cd7c4f1b26dc604fc6a04dd02bc8",
     "@parity/plugin-signer-default": "github:parity-js/plugin-signer-default#dcf8cf23bb050070b6a691413b974b5c2d7d1ce6",

--- a/src/Dapp/dapp.js
+++ b/src/Dapp/dapp.js
@@ -42,7 +42,8 @@ export default class Dapp extends Component {
 
   state = {
     app: null,
-    loading: true
+    loading: true,
+    token: null
   };
 
   store = DappsStore.get(this.context.api);
@@ -111,7 +112,7 @@ export default class Dapp extends Component {
     this.store
       .loadApp(id)
       .then((app) => {
-        this.setState({ loading: false, app });
+        this.setState({ loading: false, app, token: this.requestsStore.createToken(app.id) });
       })
       .catch(() => {
         this.setState({ loading: false });
@@ -144,13 +145,14 @@ export default class Dapp extends Component {
       preload={ preload }
       ref={ this.handleWebview }
       src={ `${src}${hash}` }
+      partition={ `persist:${this.state.app.id}` }
       webpreferences='contextIsolation'
            />;
   }
 
   render () {
     const { params } = this.props;
-    const { app, loading } = this.state;
+    const { app, loading, token } = this.state;
 
     if (loading) {
       return (
@@ -178,7 +180,7 @@ export default class Dapp extends Component {
       );
     }
 
-    let src = `${app.localUrl}?appId=${app.id}`;
+    let src = `${app.localUrl}?shellAppId=${app.id}&shellToken=${token}`;
 
     let hash = '';
 

--- a/src/DappRequests/store.js
+++ b/src/DappRequests/store.js
@@ -146,17 +146,13 @@ export default class Store {
   }
 
   createToken = appId => {
-    const token = sha3(`${appId}:${Date.now()}`);
+    const token = sha3(`${appId}:${Math.random()}:${Date.now()}`);
 
     this.tokens[token] = appId;
     return token;
   };
 
   hasValidToken = (method, appId, token) => {
-    if (!token) {
-      return method === 'shell_requestNewToken';
-    }
-
     return this.tokens[token] === appId;
   };
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -17,36 +17,24 @@
 import Api from '@parity/api';
 import qs from 'query-string';
 
-function getAppId () {
-  // Local dapps: file:///home/username/.config/parity-ui/dapps/mydapp/index.html?appId=LOCAL-dapp-name
-  // Local dapps served in development mode on a dedicated port: http://localhost:3001/?appId=LOCAL-dapp-name
-  // Built-in dapps: file://path-to-shell/.build/dapps/0x0587.../index.html?appId=dapp-name
-  // Built-in dapps when running Electron in dev mode: http://127.0.0.1:3000/dapps/v1/index.html?appId=dapp-name
-  // Network dapps: file:///home/username/.config/parity-ui/hashfetch/files/0x8075.../index.html?appId=dapp-name
-  const fromQuery = qs.parse(window.location.search).appId;
-
-  if (fromQuery) { return fromQuery; }
-
-  console.error('Could not find appId');
-}
-
 function initProvider () {
-  const appId = getAppId();
+  const queryParams = qs.parse(window.location.search);
+
+  // Local dapps: file:///home/username/.config/parity-ui/dapps/mydapp/index.html?appId=LOCAL-dapp-name&token=0x...
+  // Local dapps served in development mode on a dedicated port: http://localhost:3001/?appId=LOCAL-dapp-name&token=0x...
+  // Built-in dapps: file://path-to-shell/.build/dapps/0x0587.../index.html?appId=dapp-name&token=0x...
+  // Built-in dapps when running Electron in dev mode: http://127.0.0.1:3000/dapps/v1/index.html?appId=dapp-name&token=0x...
+  // Network dapps: file:///home/username/.config/parity-ui/hashfetch/files/0x8075.../index.html?appId=dapp-name&token=0x...
+  const appId = queryParams.shellAppId;
+  const token = queryParams.shellToken;
 
   // The dapp will use the PostMessage provider, send postMessages to
   // preload.js, and preload.js will relay those messages to the shell.
+  console.log(`Initializing provider with appId ${appId} and token ${token}`);
   const ethereum = new Api.Provider.PostMessage(appId);
 
-  console.log(`Requesting API communications token for ${appId}`);
-
   ethereum
-    .requestNewToken()
-    .then((tokenId) => {
-      console.log(`Received API communications token ${tokenId}`);
-    })
-    .catch((error) => {
-      console.error('Unable to retrieve communications token', error);
-    });
+    .setToken(token);
 
   window.ethereum = ethereum;
   window.isParity = true;

--- a/src/preload.js
+++ b/src/preload.js
@@ -28,11 +28,7 @@ window.addEventListener('message', (event) => {
   ipcRenderer.sendToHost('PARITY_SHELL_IPC_CHANNEL', { data: event.data });
 });
 
-// Load inject.js as a string, and inject it into the webview with executeJavaScript
-fs.readFile(path.join(remote.getGlobal('dirName'), '..', '.build', 'inject.js'), 'utf8', (err, injectFile) => {
-  if (err) {
-    console.error(err);
-    return;
-  }
-  webFrame.executeJavaScript(injectFile);
-});
+// Load inject.js as a string to inject it into the webview with executeJavaScript
+const injectFile = fs.readFileSync(path.join(remote.getGlobal('dirName'), '..', '.build', 'inject.js'), 'utf8');
+
+webFrame.executeJavaScript(injectFile);

--- a/src/shellMiddleware.js
+++ b/src/shellMiddleware.js
@@ -69,11 +69,6 @@ export default function execute (appId, method, params, callback) {
       return true;
     }
 
-    case 'shell_requestNewToken': {
-      callback(null, requestStore.createToken(appId));
-      return true;
-    }
-
     case 'shell_setAppPinned': {
       const [appId, pinned] = params;
 


### PR DESCRIPTION
Backport #177

* Use persistent storage for webviews

* Update .gitlab-ci.yml

enable gitsync

* Retrieve dapp token internally

* Remove shell_requestNewToken RPC method. The token must be retrieved internally (by importing DappsRequestsStore in Parity UI), this way we can be sure that the appId is coming from a trusted source. The token, along with the appId, are now passed as query string parameters to the dapp (and to subsequent pages during in-dapp navigation)
* Use new version of @parity/api stripped of shell_requestNewToken methods that are now unused
* Use synchronous blocking methods in preload.js to maximize chances of web3/parity/ethereum objects being available directly to the dapp, before its own js executes.